### PR TITLE
Add error handling and localization for weather providers

### DIFF
--- a/src/Asv.Drones.Gui.Weather/RS.Designer.cs
+++ b/src/Asv.Drones.Gui.Weather/RS.Designer.cs
@@ -60,6 +60,24 @@ namespace Asv.Drones.Gui.Weather {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Connection error occurred.
+        /// </summary>
+        public static string WeatherProvider_ConnectionErrorMessage {
+            get {
+                return ResourceManager.GetString("WeatherProvider_ConnectionErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error: {0} - {1}.
+        /// </summary>
+        public static string WeatherProvider_CustomErrorMessage {
+            get {
+                return ResourceManager.GetString("WeatherProvider_CustomErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Here you can change weather settings.
         /// </summary>
         public static string WeatherSettingsView_Description {

--- a/src/Asv.Drones.Gui.Weather/RS.resx
+++ b/src/Asv.Drones.Gui.Weather/RS.resx
@@ -48,4 +48,10 @@
     <data name="WeatherSettingsView_WeatherApiKey_Header" xml:space="preserve">
         <value>API key</value>
     </data>
+    <data name="WeatherProvider_ConnectionErrorMessage" xml:space="preserve">
+        <value>Connection error occurred</value>
+    </data>
+    <data name="WeatherProvider_CustomErrorMessage" xml:space="preserve">
+        <value>Error: {0} - {1}</value>
+    </data>
 </root>

--- a/src/Asv.Drones.Gui.Weather/RS.ru.resx
+++ b/src/Asv.Drones.Gui.Weather/RS.ru.resx
@@ -41,4 +41,10 @@
     <data name="WeatherSettingsView_WeatherApiKey_Description" xml:space="preserve">
         <value>Здесь вам нужно указать ваш API ключ</value>
     </data>
+    <data name="WeatherProvider_ConnectionErrorMessage" xml:space="preserve">
+        <value>Возникла ошибка соединения</value>
+    </data>
+    <data name="WeatherProvider_CustomErrorMessage" xml:space="preserve">
+        <value>Ошибка: {0} - {1}</value>
+    </data>
 </root>

--- a/src/Asv.Drones.Gui.Weather/Service/Providers/OpenWeatherMapProvider.cs
+++ b/src/Asv.Drones.Gui.Weather/Service/Providers/OpenWeatherMapProvider.cs
@@ -30,29 +30,34 @@ public class OpenWeatherMapProvider : IWeatherProviderBase
                             $"&lon={longitude}" +
                             $"&appid={ApiKey}";
 
-            HttpResponseMessage response = await client.GetAsync(apiUrl);
-
-            if (response.IsSuccessStatusCode)
+            try
             {
-                string jsonResponse = await response.Content.ReadAsStringAsync();
-            
-                OpenWeatherMapResponse openWeatherMapResponse = 
-                    JsonConvert.DeserializeObject<OpenWeatherMapResponse>(jsonResponse);
-         
-                var weatherData = new WeatherData
-                {
-                    WindSpeed = openWeatherMapResponse.Wind.Speed,
-                    WindDirection = openWeatherMapResponse.Wind.Direction,
-                    Temperature = openWeatherMapResponse.Main.Temperature
-                };
+                HttpResponseMessage response = await client.GetAsync(apiUrl);
 
-                return weatherData;
+                if (response.IsSuccessStatusCode)
+                {
+                    string jsonResponse = await response.Content.ReadAsStringAsync();
+
+                    OpenWeatherMapResponse openWeatherMapResponse =
+                        JsonConvert.DeserializeObject<OpenWeatherMapResponse>(jsonResponse);
+
+                    var weatherData = new WeatherData
+                    {
+                        WindSpeed = openWeatherMapResponse.Wind.Speed,
+                        WindDirection = openWeatherMapResponse.Wind.Direction,
+                        Temperature = openWeatherMapResponse.Main.Temperature
+                    };
+
+                    return weatherData;
+                }
+
+                _log.Error(Name,string.Format(Weather.RS.WeatherProvider_CustomErrorMessage, response.StatusCode, response.ReasonPhrase));
             }
-            
-            _log.Error(Name,"Connection error occurred");
+            catch (Exception ex)
+            {
+                _log.Error(Name,Weather.RS.WeatherProvider_ConnectionErrorMessage, ex);
+            }
         }
-        
-        
         return new WeatherData();
     }
 

--- a/src/Asv.Drones.Gui.Weather/Service/Providers/WindyProvider.cs
+++ b/src/Asv.Drones.Gui.Weather/Service/Providers/WindyProvider.cs
@@ -71,14 +71,12 @@ public class WindyProvider : IWeatherProviderBase
 
                     return weatherData;
                 }
-                else
-                {
-                    _log.Error(Name,$"Error: {response.StatusCode} - {response.ReasonPhrase}");
-                }
+
+                _log.Error(Name,string.Format(Weather.RS.WeatherProvider_CustomErrorMessage, response.StatusCode, response.ReasonPhrase));
             }
             catch (Exception ex)
             {
-                _log.Error(Name,"Connection error occurred", ex);
+                _log.Error(Name,Weather.RS.WeatherProvider_ConnectionErrorMessage, ex);
             }
         }
         

--- a/src/Asv.Drones.Gui.Weather/Shell/Pages/Map/Actions/WeatherActionViewModel.cs
+++ b/src/Asv.Drones.Gui.Weather/Shell/Pages/Map/Actions/WeatherActionViewModel.cs
@@ -78,6 +78,7 @@ public class WeatherActionViewModel : MapActionBase
     
     public override IMapAction Init(IMap context)
     {
+        base.Init(context);
         UpdateWeather = ReactiveCommand.CreateFromTask(
             () => UpdateWeatherImpl(context.Center)).DisposeItWith(Disposable);
         


### PR DESCRIPTION
This commit introduces error messages and localizes them for the WindyProvider and OpenWeatherMapProvider. When the HTTP request to fetch weather data fails or throws an exception, an error message will be logged and displayed to the user. This helps in debugging and also improves the user experience as users will be informed about the issues in their language. The error messages have been added to the Russian and default resource files. In addition, the base initialization in WeatherActionViewModel has been included for proper setup of the object.

Asana: https://app.asana.com/0/1203851531040615/1205134810486883/f